### PR TITLE
COOK-1680 application_java: deploy action missing from java_remote_file resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.1:
+
+* [COOK-1680] - Add deploy action (alias for create) to java_remote_file
+
 ## v1.0.0:
 
 * [COOK-1243] - Initial release - relates to COOK-634.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.2:
+
+* Support deploying local files
+
 ## v1.0.1:
 
 * [COOK-1680] - Add deploy action (alias for create) to java_remote_file

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ NOTICE: the `application` cookbook was designed around frameworks running on int
 - database\_master\_role: if a role name is provided, a Chef search will be run to find a node with than role in the same environment as the current role. If a node is found, its IP address will be used when rendering the context file, but see the "Database block parameters" section below
 - context\_template: the name of template that will be rendered to create the context file; if specified it will be looked up in the application cookbook. Defaults to "context.xml.erb" from this cookbook
 - database: a block containing additional parameters for configuring the database connection (see below)
-- strategy: if specified, allows overriding the default :java_remote_file with an alternate deploy strategy. use :java_local_file for files fetched externally, available on the filesystem
 
 # Database block parameters
 
@@ -64,6 +63,9 @@ The `tomcat` sub-resource LWRP configures Tomcat to run the application by creat
 Attributes
 ==========
 
+strategy: required to be one of
+	:java_remote_file allows downloading from a remote http url
+	:java_local_file allows using a package on the filesystem
 path: the target location for the application distribution. This should be outside of the tomcat deployment tree.
 repository:
 	- java_remote_file uses repository as the remote URL
@@ -80,6 +82,7 @@ A sample application that needs a database connection:
       path "/usr/local/my-app"
       repository "..."
       revision "..."
+			strategy :java_local_file
 
       java_webapp do
         database_master_role "database_master"
@@ -107,6 +110,7 @@ context file for other reasons), you can specify your own template:
       group node["tomcat"]["group"]
       repository "http://mirrors.jenkins-ci.org/war/latest/jenkins.war"
       revision "6facd94e958ecf68ffd28be371b5efcb5584c885b5f32a906e477f5f62bdb518-1"
+			strategy :java_remote_file
 
       java_webapp do
         context_template "jenkins-context.xml.erb"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The LWRPs provided by this cookbook are not meant to be used by themselves; make
 java_webapp
 -----------
 
-The `java_webapp` sub-resource LWRP deals with deploying Java webapps delivered as WAR files which will be retrieved from a remote URL.
+The `java_webapp` sub-resource LWRP deals with deploying Java webapps delivered as WAR files which will be either be retrieved from a remote URL or fetched by some other method and referenced locally.
 
 NOTICE: the `application` cookbook was designed around frameworks running on interpreted languages that are deployed in source code, checked out of an SCM using the `deploy_revision` resource. While this cookbook tries to map those concepts to a binary distribution mechanism, it may not map exactly.
 
@@ -38,6 +38,7 @@ NOTICE: the `application` cookbook was designed around frameworks running on int
 - database\_master\_role: if a role name is provided, a Chef search will be run to find a node with than role in the same environment as the current role. If a node is found, its IP address will be used when rendering the context file, but see the "Database block parameters" section below
 - context\_template: the name of template that will be rendered to create the context file; if specified it will be looked up in the application cookbook. Defaults to "context.xml.erb" from this cookbook
 - database: a block containing additional parameters for configuring the database connection (see below)
+- strategy: if specified, allows overriding the default :java_remote_file with an alternate deploy strategy. use :java_local_file for files fetched externally, available on the filesystem
 
 # Database block parameters
 
@@ -59,6 +60,16 @@ tomcat
 ------
 
 The `tomcat` sub-resource LWRP configures Tomcat to run the application by creating a symbolic link to the context file.
+
+Attributes
+==========
+
+path: the target location for the application distribution. This should be outside of the tomcat deployment tree.
+repository:
+	- java_remote_file uses repository as the remote URL
+	- java_local_file uses repository as the source file location on the disk
+revision: name of the war file on disk, should change with each new version
+
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ License and Author
 ==================
 
 Author:: Adam Jacob (<adam@opscode.com>)
-Author:: Andrea Campi (<andrea.campi@zephirworks.com.com>)
+Author:: Andrea Campi (<andrea.campi@zephirworks.com>)
+Author:: Jesse Campbell (<hikeit@gmail.com>)
 Author:: Joshua Timberman (<joshua@opscode.com>)
 Author:: Seth Chisamore (<schisamo@opscode.com>)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The LWRPs provided by this cookbook are not meant to be used by themselves; make
 java_webapp
 -----------
 
-The `java_webapp` sub-resource LWRP deals with deploying Java webapps delivered as WAR files which will be either be retrieved from a remote URL or fetched by some other method and referenced locally.
+The `java_webapp` sub-resource LWRP deals with deploying Java webapps delivered as WAR files which will either be retrieved from a remote URL or fetched by some other method and referenced locally.
 
 NOTICE: the `application` cookbook was designed around frameworks running on interpreted languages that are deployed in source code, checked out of an SCM using the `deploy_revision` resource. While this cookbook tries to map those concepts to a binary distribution mechanism, it may not map exactly.
 

--- a/libraries/provider_java_local_file.rb
+++ b/libraries/provider_java_local_file.rb
@@ -1,0 +1,55 @@
+#
+# Cookbook Name:: application_java
+# Library:: provider_java_local_file
+#
+# Copyright 2012, ZephirWorks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/provider/file'
+
+class Chef
+  class Provider
+		class File
+			class JavaLocalFile < Chef::Provider::File
+
+      def load_current_resource
+        @new_resource.path @new_resource.release_path
+        super
+      end
+
+      def action_deploy
+        action_create
+      end
+
+			def action_force_deploy
+				action_create
+			end
+
+			def set_content
+				unless compare_content
+					backup @new_resource.path if ::File.exists?(@new_resource.path)
+					::FileUtils.cp_r(@new_resource.content, @new_resource.path)
+					Chef::Log.info("#{@new_resource.content} copied to #{@new_resource.path}")
+					@new_resource.updated_by_last_action(true)
+				end
+			end
+
+			def compare_content
+				checksum(@current_resource.path) == checksum(@new_resource.content)
+			end
+			end
+    end
+  end
+end

--- a/libraries/provider_java_remote_file.rb
+++ b/libraries/provider_java_remote_file.rb
@@ -28,6 +28,14 @@ class Chef
         super
       end
 
+      def action_deploy
+        action_create
+      end
+
+      def action_force_deploy
+        action_create
+      end
+
     end
   end
 end

--- a/libraries/resource_java_local_file.rb
+++ b/libraries/resource_java_local_file.rb
@@ -1,0 +1,67 @@
+#
+# Cookbook Name:: application_java
+# Library:: resource_java_local_file
+#
+# Copyright 2012, ZephirWorks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource/file'
+
+class Chef
+  class Resource
+    class JavaLocalFile < Chef::Resource::File
+
+      alias :user :owner
+      alias :repository :content
+
+      def initialize(name, run_context=nil)
+        super
+        @resource_name = :java_local_file
+        @provider = Chef::Provider::File::JavaLocalFile
+        @deploy_to = nil
+        @allowed_actions.push(:deploy,:force_deploy)
+      end
+
+      def provider
+        Chef::Provider::File::JavaLocalFile
+      end
+
+      def deploy_to(args=nil)
+        set_or_return(
+          :deploy_to,
+          args,
+          :kind_of => String
+        )
+      end
+
+      def revision(arg=nil)
+        set_or_return(
+          :checksum,
+          arg,
+          :kind_of => String
+        )
+      end
+
+      def release_path
+        @release_path ||= @deploy_to + "/releases/#{revision}.war"
+      end
+
+      def method_missing(name, *args, &block)
+        Chef::Log.info "java_local_file missing(#{name}, #{args.inspect}), ignoring it"
+      end
+
+    end
+  end
+end

--- a/libraries/resource_java_remote_file.rb
+++ b/libraries/resource_java_remote_file.rb
@@ -32,6 +32,7 @@ class Chef
         @resource_name = :java_remote_file
         @provider = Chef::Provider::JavaRemoteFile
         @deploy_to = nil
+        @allowed_actions.push(:deploy,:force_deploy)
       end
 
       def provider

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "andrea.campi@zephirworks.com"
 license          "Apache 2.0"
 description      "Deploys and configures Java-based applications"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.0"
+version          "1.0.1"
 
 %w{ application java tomcat }.each do |cb|
   depends cb

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "andrea.campi@zephirworks.com"
 license          "Apache 2.0"
 description      "Deploys and configures Java-based applications"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.1"
+version          "1.0.2"
 
 %w{ application java tomcat }.each do |cb|
   depends cb

--- a/providers/java_webapp.rb
+++ b/providers/java_webapp.rb
@@ -20,11 +20,6 @@
 include Chef::Mixin::LanguageIncludeRecipe
 
 action :before_compile do
-
-  # include_recipe 'java'
-	unless new_resource.defined?( strategy )
-		new_resource.strategy :java_remote_file
-	end
 end
 
 action :before_deploy do

--- a/providers/java_webapp.rb
+++ b/providers/java_webapp.rb
@@ -22,8 +22,9 @@ include Chef::Mixin::LanguageIncludeRecipe
 action :before_compile do
 
   # include_recipe 'java'
-
-  new_resource.strategy :java_remote_file
+	unless new_resource.defined?( strategy )
+		new_resource.strategy :java_remote_file
+	end
 end
 
 action :before_deploy do

--- a/providers/tomcat.rb
+++ b/providers/tomcat.rb
@@ -43,18 +43,16 @@ action :before_deploy do
     not_if "test -L #{node['tomcat']['context_dir']}/ROOT.xml"
   end
 
+  link "#{node['tomcat']['context_dir']}/#{new_resource.application.name}.xml" do
+    to "#{new_resource.application.path}/shared/#{new_resource.application.name}.xml"
+    notifies :restart, resources(:service => "tomcat")
+  end
 end
 
 action :before_migrate do
 end
 
 action :before_symlink do
-
-  link "#{node['tomcat']['context_dir']}/ROOT.xml" do
-    to "#{new_resource.application.path}/shared/#{new_resource.application.name}.xml"
-    notifies :restart, resources(:service => "tomcat")
-  end
-
 end
 
 action :before_restart do


### PR DESCRIPTION
added missing deploy action to java_remote_file

also added capability to deploy an application from a local file, to be able to fetch such a file using an external method (ftp, authenticated http, nfs, git, etc) or to allow compiling the package at deploy time.
