### PR TITLE
[COOK-3563] Replace calls to Chef::Mixin::RecipeDefinitionDSLCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Other application stacks may be supported at a later date.
 Requirements
 ============
 
-Chef 0.10.0 or higher required (for Chef environment use).
+Chef 0.11.0 or higher required (for Chef environment use).
 
 The following Opscode cookbooks are dependencies:
 

--- a/providers/java_webapp.rb
+++ b/providers/java_webapp.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 end

--- a/providers/tomcat.rb
+++ b/providers/tomcat.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::IncludeRecipe
 
 action :before_compile do
 


### PR DESCRIPTION
Replace calls to Chef::Mixin::RecipeDefinitionDSLCore with Chef::DSL::Recipe to remove deprecation warnings

https://tickets.opscode.com/browse/COOK-3563
